### PR TITLE
AV 676 email reminder expiring datasets

### DIFF
--- a/ckanext/reminder/commands.py
+++ b/ckanext/reminder/commands.py
@@ -30,6 +30,8 @@ class ReminderCommand(p.toolkit.CkanCommand):
             self.send()
         elif cmd == 'notify':
             self.notify()
+        elif cmd == 'notify-expiry':
+            self.notify_expiry()
         elif cmd == 'init':
             self.init_db()
         else:
@@ -40,6 +42,9 @@ class ReminderCommand(p.toolkit.CkanCommand):
 
     def notify(self):
         action.send_notifications()
+    
+    def notify_expiry(self):
+        action.send_expiry_notifications()
 
     def init_db(self):
         import ckan.model as model

--- a/ckanext/reminder/email_templates/expire_email_template.py
+++ b/ckanext/reminder/email_templates/expire_email_template.py
@@ -1,0 +1,55 @@
+from pylons import config
+
+"""
+    A template file for datasets that are about to expire.
+"""
+
+
+def message(days):
+    messageContent = ""
+    separator = '\n'
+    for day in days:
+        items = []
+        for item in day:
+            # WIP!
+            item["package_title"] = (item["package_title"].encode('ascii', 'ignore')).decode("utf-8")
+            items.append(
+                singleItem.format(
+                    package_id=item["package_id"],
+                    package_title=item["package_title"],
+                    resource_id=item["resource_id"],
+                    broken_url=item["broken_url"],
+                    site_url=config['ckan.site_url'],
+                ).encode('utf-8')
+            )
+        messageContent += separator.join(items)
+    return messageTemplate.format(content=messageContent)
+
+
+subject = "You have datasets that are about to expire"
+
+
+messageTemplate = """
+You have datasets that are about to expire.
+You can update the "valid till" date by logging in and navigating to the expiring dataset.
+
+{content}
+---
+
+Best regards
+
+Avoindata.fi support
+avoindata@vrk.fi
+"""
+
+
+singleItem = """
+Dataset: {package_title} ( {site_url}/data/fi/dataset/{package_id} )
+Valid till: {valid_till}
+"""
+
+dayGroup = """
+Expiring in {days} day(s)
+---
+{items}
+"""

--- a/ckanext/reminder/email_templates/expire_email_template.py
+++ b/ckanext/reminder/email_templates/expire_email_template.py
@@ -6,32 +6,31 @@ from pylons import config
 
 
 def message(days):
-    messageContent = ""
+    groupedByDate = []
     separator = '\n'
-    for day in days:
+    for day, expiring in days.iteritems():
         items = []
-        for item in day:
-            # WIP!
+        for item in expiring:
             item["package_title"] = (item["package_title"].encode('ascii', 'ignore')).decode("utf-8")
             items.append(
                 singleItem.format(
                     package_id=item["package_id"],
                     package_title=item["package_title"],
-                    resource_id=item["resource_id"],
-                    broken_url=item["broken_url"],
+                    valid_till=item["valid_till"],
                     site_url=config['ckan.site_url'],
-                ).encode('utf-8')
+                )
             )
-        messageContent += separator.join(items)
-    return messageTemplate.format(content=messageContent)
+        groupedByDate.append(dayGroup.format(days=day, items=separator.join(items)))
+    return messageTemplate.format(content=separator.join(groupedByDate))
 
 
 subject = "You have datasets that are about to expire"
 
 
 messageTemplate = """
-You have datasets that are about to expire.
-You can update the "valid till" date by logging in and navigating to the expiring dataset.
+You have datasets that are about to expire. When they expire they will be marked as expired.
+If you want to you extend the validity by logging in and navigating to the expiring dataset and
+updating the "valid till" field.
 
 {content}
 ---
@@ -45,10 +44,10 @@ avoindata@vrk.fi
 
 singleItem = """
 Dataset: {package_title} ( {site_url}/data/fi/dataset/{package_id} )
-Valid till: {valid_till}
-"""
+Valid till: {valid_till}"""
 
 dayGroup = """
+---
 Expiring in {days} day(s)
 ---
 {items}

--- a/ckanext/reminder/logic/action.py
+++ b/ckanext/reminder/logic/action.py
@@ -182,17 +182,15 @@ def send_expiry_notifications():
         for days in expireInDays:
             if (valid_till - datetime.timedelta(days=days)) == today:
                 # add to group of notifications to send
-                print 'add to group "%s days"' % days
                 add_to_grouped(maintainer, maintainer_email, package_id, days, valid_till, package_title)
 
     # Create email to each maintainer and send them
     for maintainer_name, maintainer_details in grouped_by_maintainer.iteritems():
         subject = expire_email_template.subject
         body = expire_email_template.message(maintainer_details["expiring"])
-        print body
         mail_recipient(maintainer_name, maintainer_details["email"], subject, body)
 
-    print grouped_by_maintainer
+    log.info("Expiration notification emails sent")
 
 
 def subscribe_to_package(context, data_dict):


### PR DESCRIPTION
added a function that goes through all expiring datasets, and groups them in three groups: 14days, 5days and 1day to expiration.

Then sends messages emails to the maintainers of those datasets.